### PR TITLE
Typo in schema.prisma

### DIFF
--- a/packages/db/prisma/migrations/20231011012804_fix_typo/migration.sql
+++ b/packages/db/prisma/migrations/20231011012804_fix_typo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "MembershipProof" RENAME COLUMN "craetedAt"  TO "createdAt";

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -16,6 +16,6 @@ model MembershipProof {
   publicInput String
   merkleRoot  String?
   message     String
-  craetedAt   DateTime @default(now())
+  createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }


### PR DESCRIPTION
I believe this is a typo, unless you are trying to avoid collisions your in db.